### PR TITLE
fix errors with viewing another person's account

### DIFF
--- a/app/components/account/Account.tsx
+++ b/app/components/account/Account.tsx
@@ -129,18 +129,24 @@ export const Account: FC<Props> = ({ self }) => {
   }, [!!account?.result]);
 
   const fetchProfileNFT = async () => {
+    const walletKey =
+      router.query.account !== undefined
+        ? account?.result.wallets.filter((wallet) => wallet.hasProfileNFT)[0]
+            ?.publicKey
+        : currentWallet.publicKey.toString();
     const nfts = await underdogClient.getNfts({
       params: PROFILE_PROJECT_PARAMS,
       query: {
         page: 1,
         limit: 1,
-        ownerAddress: currentWallet.publicKey.toString(),
+        ownerAddress: walletKey,
       },
     });
+
     if (nfts.totalResults > 0) {
-      const { name, attributes, image } = nfts.results[0];
+      const { attributes, image } = nfts.results[0];
       const profileNFT: ProfileNFT = {
-        name: name,
+        name: account?.result.name,
         reputation: attributes.reputation as number,
         badges:
           attributes.badges !== ""
@@ -262,7 +268,8 @@ export const Account: FC<Props> = ({ self }) => {
           {/* right column */}
           <div className="flex flex-col gap-5 w-full">
             <QuestsCard />
-            <ReferCard />
+
+            {account?.result.id === currentUser.id && <ReferCard />}
           </div>
         </div>
       )}

--- a/app/components/account/components/ProfileNFTCard.tsx
+++ b/app/components/account/components/ProfileNFTCard.tsx
@@ -225,7 +225,7 @@ export const ProfileNFTCard = ({
           </div>
           {/* Data column */}
           <div className="flex flex-col gap-4 text-lg text-textPrimary">
-            <p>{currentUser?.name}</p>
+            <p>{profileNFT?.name}</p>
             {/* <p>{currentUser?.name}</p> */}
             {/* TODO: hard coded */}
             <div className="flex items-center gap-2">

--- a/app/components/account/components/QuestsCard.tsx
+++ b/app/components/account/components/QuestsCard.tsx
@@ -1,4 +1,5 @@
 import { BountyCard } from "@/components";
+import { useUserWallet } from "@/src/providers";
 import { BountyPreview, IAsyncResult, Industry } from "@/types/";
 import { api } from "@/utils";
 import { useRouter } from "next/router";
@@ -15,6 +16,7 @@ export const QuestsCard: FC = () => {
   const { mutateAsync: getCurrentUser } = api.users.currentUser.useMutation();
   const { mutateAsync: getAllIndustries } =
     api.industries.getAllIndustries.useMutation();
+  const { currentUser } = useUserWallet();
 
   useEffect(() => {
     const getBountiesAsync = async () => {
@@ -37,8 +39,9 @@ export const QuestsCard: FC = () => {
       } else {
         try {
           const bounties = await getBounties({
-            currentUserId: parseInt(router.query.account as string),
+            currentUserId: currentUser.id,
             onlyMyBounties: false,
+            filteredUserId: parseInt(router.query.account as string),
           });
           setBounties({
             result: bounties.slice(0, 2),

--- a/app/server/api/routers/bounties/getAllBounties.ts
+++ b/app/server/api/routers/bounties/getAllBounties.ts
@@ -7,8 +7,15 @@ export const getAllBounties = protectedProcedure
     z.object({
       currentUserId: z.number(),
       onlyMyBounties: z.boolean(),
+      filteredUserId: z.optional(z.number()),
     })
   )
-  .mutation(async ({ input: { currentUserId, onlyMyBounties } }) => {
-    return await queries.bounty.getMany(currentUserId, onlyMyBounties);
-  });
+  .mutation(
+    async ({ input: { currentUserId, onlyMyBounties, filteredUserId } }) => {
+      return await queries.bounty.getMany(
+        currentUserId,
+        onlyMyBounties,
+        filteredUserId
+      );
+    }
+  );


### PR DESCRIPTION
- Filter by only public bounties for previous bounties
- Display the profile nft for the first wallet they own that has a profile nft
- Change to display the account.name instead of currentUser.name
- remove the referral link section