### PR TITLE
[LAN-127]: Hotfix - tags on published quests overflowing

### DIFF
--- a/app/components/molecules/BountyCard.tsx
+++ b/app/components/molecules/BountyCard.tsx
@@ -40,7 +40,7 @@ const BountyCard: FC<BountyCardProps> = ({
     : null;
 
   const displayedTags = bounty
-    ? bounty.tags.map((tag) => tag.name)
+    ? bounty.tags.slice(0, 4).map((tag) => tag.name)
     : formData.tags.slice(0, 4).map((tag) => tag);
 
   const tagOverflow = bounty


### PR DESCRIPTION
There was a missing `.slice(0, 4)` call for published Quests. This was only applying to preview quests.