### PR TITLE
[LAN-163]: Hotfix: Resume Modal Still Appears After Upload

### DIFF
--- a/app/components/account/Account.tsx
+++ b/app/components/account/Account.tsx
@@ -122,12 +122,12 @@ export const Account: FC<Props> = ({ self }) => {
     }
   }, [fetchedUser, currentWallet, currentTutorialState]);
 
-  // check for "newUser" key in local storage
+  // check for resume in user object
   useEffect(() => {
-    if (localStorage.getItem("newUser")) {
+    if (!!fetchedUser && !fetchedUser.resume) {
       setShowResumeModal(true);
     }
-  }, []);
+  }, [fetchedUser]);
 
   if (!IS_CUSTODIAL && !currentWallet && !profileNFT)
     return (
@@ -146,7 +146,7 @@ export const Account: FC<Props> = ({ self }) => {
   if (userLoading) {
     return (
       <div className="w-full md:w-[90%] items-center justify-center flex flex-col mx-auto px-4 md:px-0 py-24">
-        <LoadingBar title={"Loading profile"} />
+        <LoadingBar title={"Loading Profile"} />
       </div>
     );
   }

--- a/app/components/account/components/ResumeCard.tsx
+++ b/app/components/account/components/ResumeCard.tsx
@@ -67,7 +67,6 @@ const ResumeCard: React.FC<{
 
   const handleResumeUpload = async (url) => {
     const { resume } = await updateResume({ resume: url });
-    localStorage.removeItem("newUser");
     setResumeUrl(resume);
     setShowModal && setShowModal(false);
   };
@@ -78,7 +77,6 @@ const ResumeCard: React.FC<{
       await updateResume({ resume: "" });
       await deleteResume({ fileUrl: resumeUrl });
       setResumeUrl("");
-      localStorage.setItem("newUser", "true");
     } catch (error) {
       console.log(error);
       toast.error(`Error deleting resume: ${error.message}`);

--- a/app/components/onboarding/Onboard.tsx
+++ b/app/components/onboarding/Onboard.tsx
@@ -141,8 +141,6 @@ const Onboard: FC = () => {
         website: profileData.website,
       });
       toast.success("Profile created successfully!", { id: toastId });
-      // save "newUser" in local storage
-      localStorage.setItem("newUser", "true");
       router.push("/account");
     } catch (e) {
       console.log("error updating profile: ", e);

--- a/app/components/organisms/ResumeModal.tsx
+++ b/app/components/organisms/ResumeModal.tsx
@@ -7,7 +7,6 @@ import { User } from "@/types";
 
 interface Props {
   setShowModal: Dispatch<SetStateAction<boolean>>;
-
   resumeUrl: string;
   setResumeUrl: (value: string) => void;
 }


### PR DESCRIPTION
- Removes use of local storage in favor of `resume` field on user object