### PR TITLE
Hotfix: Leaderboard Under Construction

### DIFF
--- a/app/pages/leaderboard/commits.tsx
+++ b/app/pages/leaderboard/commits.tsx
@@ -50,7 +50,10 @@ export default function Home() {
         <meta name="description" content="Lancer Leaderboard" />
       </Head>
       <main>
-        <LeaderboardCommits self={true} />
+        {/* <LeaderboardCommits self={true} /> */}
+        <h1 className="py-32 w-fit mx-auto text-center">
+          Leaderboard Under Construction
+        </h1>
       </main>
     </>
   );

--- a/app/pages/leaderboard/contributions.tsx
+++ b/app/pages/leaderboard/contributions.tsx
@@ -50,7 +50,10 @@ export default function Home() {
         <meta name="description" content="Lancer Contribution Leaderboard" />
       </Head>
       <main>
-        <ContributionBoard />
+        {/* <ContributionBoard /> */}
+        <h1 className="py-32 w-fit mx-auto text-center">
+          Leaderboard Under Construction
+        </h1>
       </main>
     </>
   );

--- a/app/pages/leaderboard/earners.tsx
+++ b/app/pages/leaderboard/earners.tsx
@@ -59,7 +59,10 @@ export default function Home() {
         <meta name="description" content="Lancer Leaderboard" />
       </Head>
       <main>
-        <TopEarnersBoard />
+        {/* <TopEarnersBoard /> */}
+        <h1 className="py-32 w-fit mx-auto text-center">
+          Leaderboard Under Construction
+        </h1>
       </main>
     </>
   );

--- a/app/pages/leaderboard/index.tsx
+++ b/app/pages/leaderboard/index.tsx
@@ -51,7 +51,10 @@ export default function Home() {
         <meta name="description" content="Lancer Bounty Leaderboard" />
       </Head>
       <main>
-        <TopQuestUsersBoard />
+        {/* <TopQuestUsersBoard /> */}
+        <h1 className="py-32 w-fit mx-auto text-center">
+          Leaderboard Under Construction
+        </h1>
       </main>
     </>
   );


### PR DESCRIPTION
- Replaces all Leaderboard components with a centered header that says "Leaderboard Under Construction"
- Should be reverted/updated after cron job for GitHub data is complete and db is migrated