### PR TITLE
[LAN-305] Fix bounty creation error flow

### DIFF
--- a/app/components/create/components/CreateBountyForm.tsx
+++ b/app/components/create/components/CreateBountyForm.tsx
@@ -91,10 +91,16 @@ export const CreateBountyForm: FC<Props> = ({
         mintKey
       );
 
-      const { timestamp, signature, escrowKey } = await createFFA(
+      const { timestamp, signature, escrowKey, error } = await createFFA(
         currentWallet,
         program
       );
+
+      if (error){
+        setCreateQuestState(error);
+        toast.error(error)
+        return
+      }
       const bounty: Bounty = await mutateAsync({
         email: currentUser.email,
         industryIds: [formData.industryId],
@@ -135,7 +141,6 @@ export const CreateBountyForm: FC<Props> = ({
       );
       console.log("Second gasless tx res: ", res2);
     } catch (error) {
-      console.log("Quest Error: ", error);
       setCreateQuestState({ error });
       if (error.message === "Wallet is registered to another user") {
         toast.error(

--- a/app/escrow/adapters/createFeatureFundingAccount.ts
+++ b/app/escrow/adapters/createFeatureFundingAccount.ts
@@ -35,10 +35,16 @@ export const createFFA = async (
   const res = await sendGaslessTx([ix]);
   console.log("Sending out second tx");
 
-  return {
-    timestamp,
-    signature: res.signature,
-    creator: new PublicKey(wallet.publicKey),
-    escrowKey: account,
-  };
+  if (res.status == "error") {
+    return {
+      error: res.message,
+    };
+  } else {
+    return {
+      timestamp,
+      signature: res.signature,
+      creator: new PublicKey(wallet.publicKey),
+      escrowKey: account,
+    };
+  }
 };

--- a/app/escrow/gasless.ts
+++ b/app/escrow/gasless.ts
@@ -32,5 +32,7 @@ export const sendGaslessTx = async (instructions: TransactionInstruction[], sign
     const json = await res.json()
     return {
         signature: json.txid,
+        status: json.status,
+        message: json.message,
     };
 }

--- a/app/pages/api/gasless/index.ts
+++ b/app/pages/api/gasless/index.ts
@@ -93,8 +93,14 @@ export default async function handler(
     Buffer.from(base58.decode(signature))
   );
 
-  const txid = await connection.sendRawTransaction(transaction.serialize());
+  try {
+    const txid = await connection.sendRawTransaction(transaction.serialize());
 
-  console.log("Tx Id: ", txid);
-  res.status(200).json({ status: "ok", txid });
+    console.log("Tx Id: ", txid);
+    res.status(200).json({ status: "ok", txid });
+  }
+  catch (e) {
+    res.status(200).json({ status: "error", message: e.toString() })
+
+  }
 }


### PR DESCRIPTION
This PR fixes the issue of bounty being created in database even if there is some error with on-chain transaction. 

Now, a toast error is shown whenever there is error coming in from gasless server transaction response